### PR TITLE
Remove Graphite and StatsD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,6 @@ RUN set -ex \
         /usr/share/doc \
         /usr/share/doc-base
 
-
 COPY script/entrypoint.sh /entrypoint.sh
 COPY config/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
 COPY airflow_home/ ${AIRFLOW_HOME}
@@ -72,7 +71,7 @@ COPY airflow_home/ ${AIRFLOW_HOME}
 RUN mkdir ${AIRFLOW_HOME}/temp
 RUN chown -R airflow: ${AIRFLOW_HOME}
 
-EXPOSE 8080 5555 8793
+EXPOSE 8080 5555
 
 USER airflow
 WORKDIR ${AIRFLOW_HOME}

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -416,8 +416,8 @@ catchup_by_default = True
 max_tis_per_query = 512
 
 # Statsd (https://github.com/etsy/statsd) integration settings
-statsd_on = True
-statsd_host = graphite
+statsd_on = False
+statsd_host = localhost
 statsd_port = 8125
 statsd_prefix = airflow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,19 +16,6 @@ services:
         interval: 30s
         timeout: 10s
         retries: 5
-  graphite:
-    container_name: airflow_graphite_example
-    image: hopsoft/graphite-statsd:latest
-    ports:
-      - "8880:80"
-      - "8881:81"
-      - "8125:8125"
-      - "8126:8126"
-    healthcheck:
-        test: ["CMD", "curl", "-f", "http://localhost:80"]
-        interval: 30s
-        timeout: 10s
-        retries: 5
   airflow:
     build: .
     image: airflow_compose:latest
@@ -43,10 +30,7 @@ services:
     ports:
       - "8080:8080"
       - "5555:5555"
-      - "8793:8793"
     depends_on:
       - postgres
-      - graphite
     links:
       - postgres:postgres
-      - graphite:graphite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow[celery,crypto,emr,hive,hdfs,ldap,mysql,postgres,redis,slack,s3,kubernetes,statsd]==1.10.4
+apache-airflow[celery,crypto,emr,hive,hdfs,ldap,mysql,postgres,redis,s3,kubernetes]==1.10.4
 celery[redis]>=4.1.1,<4.2.0
 cython==0.29
 certifi==2018.4.16
@@ -19,9 +19,7 @@ lxml>=4.0.0
 Mako==1.0.7
 Markdown==2.6.11
 MarkupSafe==1.0
-numpy==1.15.0
 ordereddict==1.1
-pandas==0.23.3
 psutil==4.4.2
 Pygments==2.2.0
 python-daemon==2.1.2


### PR DESCRIPTION
<!-- Fill out this template to explain your pull request. -->

# Related Tickets
<!-- Please link to any related tickets -->

#9 

Reverts https://github.com/frankcash/airflow_compose/pull/4 as prometheus exporter is now implemented in #7 


# Changes proposed
<!-- Describe the changes you've made so it's easier for the team to review. -->

- Removes Pandas and Numpy installs
- Removes slack and statsd packages for airflow
- Removes graphite pod

#### Expected Output
Only Postgres and Airflow images should be brought up

![Screen Shot 2019-08-09 at 8 15 39 AM](https://user-images.githubusercontent.com/6012231/62789645-3a673a00-ba7e-11e9-98fc-f0b940776d95.png)


#### Caveats
<!-- If there is anything hacky or unique being added in your code please define it.-->

